### PR TITLE
Add annotate gem & add url_id column.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,8 @@ group :development do
   gem "noncommittal"
   # Ruby Style Guide, with linter & automatic code fixer (https://github.com/testdouble/standard)
   gem "standard"
+  # Annotates Rails/ActiveRecord Models, routes, fixtures, and others based on the database schema. (https://github.com/ctran/annotate_models)
+  gem "annotate"
 
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
   # gem "rack-mini-profiler"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,9 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
+    annotate (3.2.0)
+      activerecord (>= 3.2, < 8.0)
+      rake (>= 10.4, < 14.0)
     ast (2.4.2)
     base64 (0.1.1)
     bigdecimal (3.1.4)
@@ -284,6 +287,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  annotate
   bootsnap
   brakeman
   capybara

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1,3 +1,26 @@
+# == Schema Information
+#
+# Table name: boards
+#
+#  id         :bigint           not null, primary key
+#  public     :boolean          default(FALSE)
+#  title      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  url_id     :string           not null
+#
+# Indexes
+#
+#  index_boards_on_url_id  (url_id)
+#
 class Board < ApplicationRecord
+  after_initialize :set_url_id
+
   scope :ordered, -> { order(id: :desc) }
+
+  private
+
+  def set_url_id
+    self.url_id ||= SecureRandom.urlsafe_base64
+  end
 end

--- a/db/migrate/20231117140159_add_url_id_to_boards.rb
+++ b/db/migrate/20231117140159_add_url_id_to_boards.rb
@@ -1,0 +1,11 @@
+class AddUrlIdToBoards < ActiveRecord::Migration[7.1]
+  def up
+    add_column :boards, :url_id, :string, null: false
+    add_index :boards, :url_id
+  end
+
+  def down
+    remove_index :boards, :url_id
+    remove_column :boards, :url_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_05_182825) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_17_140159) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,8 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_05_182825) do
     t.boolean "public", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "url_id", null: false
+    t.index ["url_id"], name: "index_boards_on_url_id"
   end
 
 end

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,59 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require "annotate"
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      "active_admin" => "false",
+      "additional_file_patterns" => [],
+      "routes" => "false",
+      "models" => "true",
+      "position_in_routes" => "before",
+      "position_in_class" => "before",
+      "position_in_test" => "before",
+      "position_in_fixture" => "before",
+      "position_in_factory" => "before",
+      "position_in_serializer" => "before",
+      "show_foreign_keys" => "true",
+      "show_complete_foreign_keys" => "false",
+      "show_indexes" => "true",
+      "simple_indexes" => "false",
+      "model_dir" => "app/models",
+      "root_dir" => "",
+      "include_version" => "false",
+      "require" => "",
+      "exclude_tests" => "false",
+      "exclude_fixtures" => "false",
+      "exclude_factories" => "false",
+      "exclude_serializers" => "false",
+      "exclude_scaffolds" => "true",
+      "exclude_controllers" => "true",
+      "exclude_helpers" => "true",
+      "exclude_sti_subclasses" => "false",
+      "ignore_model_sub_dir" => "false",
+      "ignore_columns" => nil,
+      "ignore_routes" => nil,
+      "ignore_unknown_models" => "false",
+      "hide_limit_column_types" => "integer,bigint,boolean",
+      "hide_default_column_types" => "json,jsonb,hstore",
+      "skip_on_db_migrate" => "false",
+      "format_bare" => "true",
+      "format_rdoc" => "false",
+      "format_yard" => "false",
+      "format_markdown" => "false",
+      "sort" => "false",
+      "force" => "false",
+      "frozen" => "false",
+      "classified_sort" => "true",
+      "trace" => "false",
+      "wrapper_open" => nil,
+      "wrapper_close" => nil,
+      "with_comment" => "true"
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/test/fixtures/boards.yml
+++ b/test/fixtures/boards.yml
@@ -1,9 +1,25 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: boards
+#
+#  id         :bigint           not null, primary key
+#  public     :boolean          default(FALSE)
+#  title      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  url_id     :string           not null
+#
+# Indexes
+#
+#  index_boards_on_url_id  (url_id)
+#
 
 one:
   title: MyString
   public: false
+  url_id: url_id_one
 
 two:
   title: MyString
   public: false
+  url_id: url_id_two


### PR DESCRIPTION
This PR adds a new column, `url_id` that is used to replace the ID that is used to access Boards. This is implemented to prevent boards from being accessed publicly.